### PR TITLE
Fix for e2e metrics integration

### DIFF
--- a/packages/aio-metrics-client/src/index.js
+++ b/packages/aio-metrics-client/src/index.js
@@ -2,7 +2,6 @@ let batchedMetrics = {}
 let metricsMetadata = {}
 let batchTimerSet = false
 let metricsURL = ''
-let metricsEndPoint
 
 const fetch = require('node-fetch')
 
@@ -13,8 +12,7 @@ function createMetric (metricName, labels) {
 
 function setMetricsConfig (metricsPostURL, endpoint) {
   console.log('setting metrics config')
-  metricsURL = metricsPostURL
-  metricsEndPoint = endpoint
+  metricsURL = metricsPostURL + endpoint
 }
 
 async function processBatchCounter() {
@@ -26,8 +24,7 @@ async function processBatchCounter() {
     
     Object.keys(batchedMetrics).forEach(async (metricName) => {
       console.log('Sending Batch metrics for ' + metricName)
-      const postBody = JSON.stringify( { metrics_data: { metric: metricName, data: batchedMetrics[metricName] }, endpoint: metricsEndPoint,
-      namespace: namespace, auth: auth } )
+      const postBody = JSON.stringify({ metric: metricName, data: batchedMetrics[metricName] })
       delete batchedMetrics.metricName
       const reqData = {
         method: 'POST',

--- a/packages/aio-metrics-client/src/index.js
+++ b/packages/aio-metrics-client/src/index.js
@@ -20,9 +20,14 @@ function setMetricsConfig (metricsPostURL, endpoint) {
 async function processBatchCounter() {
   batchTimerSet = false
   if (metricsURL) {
+    //get action namespace and auth
+    const namespace = process.env.__OW_NAMESPACE
+    const auth = process.env.__OW_API_KEY
+    
     Object.keys(batchedMetrics).forEach(async (metricName) => {
       console.log('Sending Batch metrics for ' + metricName)
-      const postBody = JSON.stringify( { metrics_data: { metric: metricName, data: batchedMetrics[metricName] }, endpoint: metricsEndPoint } )
+      const postBody = JSON.stringify( { metrics_data: { metric: metricName, data: batchedMetrics[metricName] }, endpoint: metricsEndPoint,
+      namespace: namespace, auth: auth } )
       delete batchedMetrics.metricName
       const reqData = {
         method: 'POST',

--- a/packages/aio-metrics-client/src/index.js
+++ b/packages/aio-metrics-client/src/index.js
@@ -2,6 +2,7 @@ let batchedMetrics = {}
 let metricsMetadata = {}
 let batchTimerSet = false
 let metricsURL = ''
+let metricsEndPoint
 
 const fetch = require('node-fetch')
 
@@ -10,9 +11,10 @@ function createMetric (metricName, labels) {
   console.log(metricsMetadata)
 }
 
-function setMetricsURL (metricsPostURL) {
-  console.log('setting the metrics url')
+function setMetricsConfig (metricsPostURL, endpoint) {
+  console.log('setting metrics config')
   metricsURL = metricsPostURL
+  metricsEndPoint = endpoint
 }
 
 async function processBatchCounter() {
@@ -20,7 +22,7 @@ async function processBatchCounter() {
   if (metricsURL) {
     Object.keys(batchedMetrics).forEach(async (metricName) => {
       console.log('Sending Batch metrics for ' + metricName)
-      const postBody = JSON.stringify({metric: metricName, data: batchedMetrics[metricName]})
+      const postBody = JSON.stringify({metric: metricName, data: batchedMetrics[metricName], endpoint: metricsEndPoint})
       delete batchedMetrics.metricName
       const reqData = {
         method: 'POST',
@@ -66,6 +68,6 @@ async function incBatchCounter (metricName, namespace, label) {
 
 module.exports = {
     createMetric,
-    setMetricsURL,
+    setMetricsConfig,
     incBatchCounter
 }

--- a/packages/aio-metrics-client/src/index.js
+++ b/packages/aio-metrics-client/src/index.js
@@ -22,7 +22,7 @@ async function processBatchCounter() {
   if (metricsURL) {
     Object.keys(batchedMetrics).forEach(async (metricName) => {
       console.log('Sending Batch metrics for ' + metricName)
-      const postBody = JSON.stringify({metric: metricName, data: batchedMetrics[metricName], endpoint: metricsEndPoint})
+      const postBody = JSON.stringify( { metrics_data: { metric: metricName, data: batchedMetrics[metricName] }, endpoint: metricsEndPoint } )
       delete batchedMetrics.metricName
       const reqData = {
         method: 'POST',


### PR DESCRIPTION
Added `setMetricsConfig` method which takes care of setting these two data in lib (base url and endpoint)
All clients will need to switch to this new way of  configuring metrics lib.
ex. usage, Login action will use it like `setMetricsConfig('<metrics action url>', 'recordloginmetrics')`

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
manual tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
