### PR TITLE
fix: learnings from first run

### DIFF
--- a/packages/aio-batch-update/index.js
+++ b/packages/aio-batch-update/index.js
@@ -83,9 +83,14 @@ const main = async () => {
         `${config.branch}`,
         '--commit-message',
         `${config.commitMessage}`,
+        '--no-skip-ci',
+        '--seconds-between-prs',
+        '30',
+        '--seconds-to-wait-when-ratelimited',
+        '60',
         'git',
         'apply',
-        `${__dirname}/patches/${config.patch}`
+        `${__dirname}/patches/${config.patch}`,
     ], {
         stdio: 'inherit'
     })

--- a/packages/aio-batch-update/index.js
+++ b/packages/aio-batch-update/index.js
@@ -86,7 +86,7 @@ const main = async () => {
         '--no-skip-ci',
         '--seconds-between-prs',
         '30',
-        '--seconds-to-wait-when-ratelimited',
+        '--seconds-to-wait-when-rate-limited',
         '60',
         'git',
         'apply',

--- a/packages/aio-batch-update/patches/add-secrets-inherit-nodejs-ci-no-newline.patch
+++ b/packages/aio-batch-update/patches/add-secrets-inherit-nodejs-ci-no-newline.patch
@@ -1,0 +1,12 @@
+diff --git a/.github/workflows/node.js.yml b/.github/workflows/node.js.yml
+index 967f5c2..c7ce1db 100644
+--- a/.github/workflows/node.js.yml
++++ b/.github/workflows/node.js.yml
+@@ -11,4 +11,5 @@ on:
+ 
+ jobs:
+   build:
+-    uses: adobe/aio-reusable-workflows/.github/workflows/node.js.yml@main
+\ No newline at end of file
++    uses: adobe/aio-reusable-workflows/.github/workflows/node.js.yml@main
++    secrets: inherit


### PR DESCRIPTION
- dont skip ci when making batch PRs
- wait 30s between making PRs to try to avoid rate limiting
- wait 60s between rate limited requests, if rate limited
- historical - add additional codecov patch that handles node.js.yml files without a newline