### PR TITLE
feat: multiple labels

### DIFF
--- a/packages/aio-metrics-client/src/index.js
+++ b/packages/aio-metrics-client/src/index.js
@@ -6,12 +6,12 @@ let metricsURL = ''
 
 const fetch = require('node-fetch')
 
-function createMetric (metricName, labels) {
+function createMetric(metricName, labels) {
   metricsMetadata[metricName] = labels
   console.log('createMetric ', metricsMetadata)
 }
 
-function setMetricsURL (metricsPostURL) {
+function setMetricsURL(metricsPostURL) {
   metricsURL = metricsPostURL
 }
 
@@ -27,7 +27,7 @@ async function processBatchCounter() {
     processPromises = processPromises.concat(Object.keys(batchedMetricsBulk).map((metricName) => {
       console.log('Sending bulk batch metrics for ', metricName, batchedMetricsBulk[metricName])
       // ex. Sending bulk batch metrics for  request_count { '14257-chimera-stage': 2 }
-      const postBody = JSON.stringify({metric: metricName, data: batchedMetricsBulk[metricName]})
+      const postBody = JSON.stringify({ metric: metricName, data: batchedMetricsBulk[metricName] })
       delete batchedMetricsBulk[metricName]
       const reqData = {
         method: 'POST',
@@ -40,10 +40,11 @@ async function processBatchCounter() {
     }))
 
     // Individual processing
-    processPromises = processPromises.concat(batchedMetrics.map((metric) => {
-      console.log('Sending batch metrics for ', metric.metric, metric)
+    processPromises = processPromises.concat(batchedMetrics.map((metric, i) => {
+      console.log('Sending batch metrics for ', JSON.stringify(metric))
       // ex. Sending batch metrics for  request_count { '14257-chimera-stage': 2 }
       const postBody = JSON.stringify(metric)
+      batchedMetrics.splice(i, 1)
       const reqData = {
         method: 'POST',
         headers: {
@@ -61,15 +62,21 @@ async function processBatchCounter() {
 }
 
 /**
- * Increment a counter metric with multiple labels
+ * Increment a counter metric
  * 
- * Note: If there isn't a label or only one label, this client uses a faster way of processing metrics 
- *       by posting multiple increments for the same namespace in a single request.
+ * Note: If you only have one label for your metric, use this function. It will batch the counter increments and send them in bulk.
+ * 
  * @param {string} metricName Name of the metric
  * @param {string} namespace Namespace
- * @param {string | Array<string>} labels Labels
+ * @param {string} Label
  */
-async function incBatchCounter (metricName, namespace, ...labels) {
+async function incBatchCounter(metricName, namespace, label) {
+
+  if (typeof label !== 'string') {
+    console.error('incBatchCounter error: label must be a string')
+    return
+  }
+
   // TODO: Error handling using Metrics metadata
   /* if (metricsMetadata[metricName].length < (arguments.length-1)) {
     console.log(`Could not update metric ${metricName} because supplied label count did not match the label definition ${JSON.stringify(metricsMetadata[metricName])}`)
@@ -78,36 +85,59 @@ async function incBatchCounter (metricName, namespace, ...labels) {
   /* console.log(batchedMetricsBulk[metricName])
   console.log(`batchTimerSet: ${batchTimerSet}`)
   console.log(`batchedMetricsBulk count: ${Object.keys(batchedMetricsBulk).length}`) */
-  if(!batchTimerSet || Object.keys(batchedMetricsBulk) > 0) {
+  if (!batchTimerSet || Object.keys(batchedMetricsBulk) > 0) {
     batchTimerSet = true
-    setTimeout(processBatchCounter, 5000 ) // 5 seconds
+    setTimeout(processBatchCounter, 5000) // 5 seconds
   }
 
   batchedMetricsBulk[metricName] = batchedMetricsBulk[metricName] || {}
 
   // If only one label or no label, use bulk processing
   // Otherwise post metrics individually
-  if (labels.length === 1) {
+  if (label) {
     batchedMetricsBulk[metricName][namespace] = batchedMetricsBulk[metricName][namespace] || {}
-    batchedMetricsBulk[metricName][namespace][labels[0]] = batchedMetricsBulk[metricName][namespace][labels[0]] || 0
-    batchedMetricsBulk[metricName][namespace][labels[0]] = batchedMetricsBulk[metricName][namespace][labels[0]] + 1
-  } 
-  else if (labels.length > 1) {
-    batchedMetrics.push({
-      metric: metricName, 
-      namespace, 
-      value: 1,
-      ...labels
-    })
+    batchedMetricsBulk[metricName][namespace][label] = batchedMetricsBulk[metricName][namespace][label] || 0
+    batchedMetricsBulk[metricName][namespace][label] = batchedMetricsBulk[metricName][namespace][label] + 1
   }
-  else {    
+  else {
     batchedMetricsBulk[metricName][namespace] = batchedMetricsBulk[metricName][namespace] || 0
     batchedMetricsBulk[metricName][namespace] = batchedMetricsBulk[metricName][namespace] + 1
   }
 }
 
+/**
+ * Increment a counter metric with multiple labels
+ * 
+ * Note: This function will send metrics in individual network requests, not in bulk.
+ * 
+ * @param {string} metricName Name of the metric
+ * @param {string} requester Name of requester
+ * @param {object} labels Labels, ex. { api: 'GET /templates', errorCategory: '500' }
+ */
+async function incBatchCounterMultiLabel(metricName, namespace, labels) {
+
+  if (!batchTimerSet || batchedMetrics.length > 0) {
+    batchTimerSet = true
+    setTimeout(processBatchCounter, 5000) // 5 seconds
+  }
+
+  if (typeof labels !== 'object') {
+    console.error('incBatchCounterMultiLabel error: labels must be an object')
+    return
+  }
+
+  batchedMetrics.push({
+    metric: metricName,
+    namespace,
+    value: 1,
+    ...labels
+  })
+}
+
+
 module.exports = {
-    createMetric,
-    setMetricsURL,
-    incBatchCounter
+  createMetric,
+  setMetricsURL,
+  incBatchCounter,
+  incBatchCounterMultiLabel
 }

--- a/packages/aio-metrics-client/src/index.js
+++ b/packages/aio-metrics-client/src/index.js
@@ -54,7 +54,7 @@ async function processBatchCounter() {
       return fetch(metricsURL, reqData)
     }))
 
-    await Promise.all(processPromises)
+    await Promise.allSettled(processPromises)
   } else {
     console.error('error: metricsURL not set, but batchedMetrics still present')
   }

--- a/packages/aio-metrics-client/src/index.js
+++ b/packages/aio-metrics-client/src/index.js
@@ -1,4 +1,5 @@
-let batchedMetrics = {}
+let batchedMetricsBulk = {}
+let batchedMetrics = []
 let metricsMetadata = {}
 let batchTimerSet = false
 let metricsURL = ''
@@ -14,14 +15,20 @@ function setMetricsURL (metricsPostURL) {
   metricsURL = metricsPostURL
 }
 
+/**
+ * Process batched metrics
+ */
 async function processBatchCounter() {
   batchTimerSet = false
   if (metricsURL) {
-    Object.keys(batchedMetrics).forEach(async (metricName) => {
-      console.log('Sending Batch metrics for ', metricName, batchedMetrics[metricName])
-      // ex. Sending Batch metrics for  request_count { '14257-chimera-stage': 2 }
-      const postBody = JSON.stringify({metric: metricName, data: batchedMetrics[metricName]})
-      delete batchedMetrics[metricName]
+    let processPromises = []
+
+    // Bulk processing
+    processPromises = processPromises.concat(Object.keys(batchedMetricsBulk).map((metricName) => {
+      console.log('Sending bulk batch metrics for ', metricName, batchedMetricsBulk[metricName])
+      // ex. Sending bulk batch metrics for  request_count { '14257-chimera-stage': 2 }
+      const postBody = JSON.stringify({metric: metricName, data: batchedMetricsBulk[metricName]})
+      delete batchedMetricsBulk[metricName]
       const reqData = {
         method: 'POST',
         headers: {
@@ -29,34 +36,73 @@ async function processBatchCounter() {
         },
         body: postBody
       }
-      await fetch(metricsURL, reqData)
-    })
+      return fetch(metricsURL, reqData)
+    }))
+
+    // Individual processing
+    processPromises = processPromises.concat(batchedMetrics.map((metric) => {
+      console.log('Sending batch metrics for ', metric.metric, metric)
+      // ex. Sending batch metrics for  request_count { '14257-chimera-stage': 2 }
+      const postBody = JSON.stringify(metric)
+      const reqData = {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: postBody
+      }
+      return fetch(metricsURL, reqData)
+    }))
+
+    await Promise.all(processPromises)
   } else {
     console.error('error: metricsURL not set, but batchedMetrics still present')
   }
 }
 
-async function incBatchCounter (metricName, namespace, label) {
+/**
+ * Increment a counter metric with multiple labels
+ * 
+ * Note: If there isn't a label or only one label, this client uses a faster way of processing metrics 
+ *       by posting multiple increments for the same namespace in a single request.
+ * @param {string} metricName Name of the metric
+ * @param {string} namespace Namespace
+ * @param {string | Array<string>} labels Labels
+ */
+async function incBatchCounter (metricName, namespace, ...labels) {
   // TODO: Error handling using Metrics metadata
   /* if (metricsMetadata[metricName].length < (arguments.length-1)) {
     console.log(`Could not update metric ${metricName} because supplied label count did not match the label definition ${JSON.stringify(metricsMetadata[metricName])}`)
     return
   } */
-  /* console.log(batchedMetrics[metricName])
+  /* console.log(batchedMetricsBulk[metricName])
   console.log(`batchTimerSet: ${batchTimerSet}`)
-  console.log(`batchedMetrics count: ${Object.keys(batchedMetrics).length}`) */
-  if(!batchTimerSet || Object.keys(batchedMetrics) > 0) {
+  console.log(`batchedMetricsBulk count: ${Object.keys(batchedMetricsBulk).length}`) */
+  if(!batchTimerSet || Object.keys(batchedMetricsBulk) > 0) {
     batchTimerSet = true
     setTimeout(processBatchCounter, 5000 ) // 5 seconds
   }
-  batchedMetrics[metricName] = batchedMetrics[metricName] || {}
-  if (label) {
-    batchedMetrics[metricName][namespace] = batchedMetrics[metricName][namespace] || {}
-    batchedMetrics[metricName][namespace][label] = batchedMetrics[metricName][namespace][label] || 0
-    batchedMetrics[metricName][namespace][label] = batchedMetrics[metricName][namespace][label] + 1
-  } else {    
-    batchedMetrics[metricName][namespace] = batchedMetrics[metricName][namespace] || 0
-    batchedMetrics[metricName][namespace] = batchedMetrics[metricName][namespace] + 1
+
+  batchedMetricsBulk[metricName] = batchedMetricsBulk[metricName] || {}
+
+  // If only one label or no label, use bulk processing
+  // Otherwise post metrics individually
+  if (labels.length === 1) {
+    batchedMetricsBulk[metricName][namespace] = batchedMetricsBulk[metricName][namespace] || {}
+    batchedMetricsBulk[metricName][namespace][labels[0]] = batchedMetricsBulk[metricName][namespace][labels[0]] || 0
+    batchedMetricsBulk[metricName][namespace][labels[0]] = batchedMetricsBulk[metricName][namespace][labels[0]] + 1
+  } 
+  else if (labels.length > 1) {
+    batchedMetrics.push({
+      metric: metricName, 
+      namespace, 
+      value: 1,
+      ...labels
+    })
+  }
+  else {    
+    batchedMetricsBulk[metricName][namespace] = batchedMetricsBulk[metricName][namespace] || 0
+    batchedMetricsBulk[metricName][namespace] = batchedMetricsBulk[metricName][namespace] + 1
   }
 }
 


### PR DESCRIPTION
~*Draft while testing*~

Related: https://git.corp.adobe.com/CNA/DevXMetricsService/pull/91/files

Allow setting multiple labels for a metric 

Counter increments with 0 or 1 label(s) still use the aggregate way of posting while counter increments with >1 labels post individually 