### PR TITLE
fix: metrics client incBatchCounter label check

### DIFF
--- a/packages/aio-metrics-client/src/index.js
+++ b/packages/aio-metrics-client/src/index.js
@@ -77,10 +77,10 @@ async function processBatchCounter () {
  * Note: If you only have one label for your metric, use this function. It will batch the counter increments and send them in bulk.
  * @param {string} metricName Name of the metric
  * @param {string} namespace Namespace
- * @param {string} label Label string (ex. 'GET /templates')
+ * @param {string} label (optional) Label string (ex. 'GET /templates')
  */
-async function incBatchCounter (metricName, namespace, label) {
-  if (label && typeof label !== 'string') {
+async function incBatchCounter (metricName, namespace, label = '') {
+  if (typeof label !== 'string') {
     console.error('incBatchCounter error: label must be a string')
     return
   }

--- a/packages/aio-metrics-client/src/index.js
+++ b/packages/aio-metrics-client/src/index.js
@@ -80,7 +80,7 @@ async function processBatchCounter () {
  * @param {string} label Label string (ex. 'GET /templates')
  */
 async function incBatchCounter (metricName, namespace, label) {
-  if (typeof label !== 'string') {
+  if (label && typeof label !== 'string') {
     console.error('incBatchCounter error: label must be a string')
     return
   }


### PR DESCRIPTION
Seeing this in aio login splunk logs: 
```
incBatchCounter error: label must be a string
```

There was a regression with the update to allow multiple labels. The type check for label that was added didn't take into account services that don't pass a label, i.e. 
```js
incBatchCounter('requests', namespace)
```

This worked before because the if check below would fail with a null value. This PR proposes making label an empty string by default. This should pass the type check, but also fail the later if check for adding the label

This ideally should've been caught with unit tests... https://github.com/adobe/aio-pkg-utils/issues/24