### PR TITLE
chore: update GitHub Actions node-version to 24

### DIFF
--- a/.github/workflows/node-ci-aio-app-builder-repos.yml
+++ b/.github/workflows/node-ci-aio-app-builder-repos.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [24.x]
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/.github/workflows/node-ci-aio-exc-app.yml
+++ b/.github/workflows/node-ci-aio-exc-app.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [24.x]
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/.github/workflows/node-ci-aio-metrics-client.yml
+++ b/.github/workflows/node-ci-aio-metrics-client.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [24.x]
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/.github/workflows/npm-publish-aio-app-builder-repos.yml
+++ b/.github/workflows/npm-publish-aio-app-builder-repos.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 18
+          node-version: 24
       - name: npm install, test, and publish
         run: |
           cd 'packages/aio-app-builder-repos/'

--- a/.github/workflows/npm-publish-aio-exc-app.yml
+++ b/.github/workflows/npm-publish-aio-exc-app.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 18
+          node-version: 24
       - name: npm install, test, and publish
         run: |
           cd 'packages/aio-exc-app/'

--- a/.github/workflows/npm-publish-aio-metrics-client.yml
+++ b/.github/workflows/npm-publish-aio-metrics-client.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 18
+          node-version: 24
       - name: npm install, test, and publish
         run: |
           cd 'packages/aio-metrics-client/'


### PR DESCRIPTION
## Summary
- Updates `node-version` to `24` in all 6 GitHub Actions workflows
- CI matrix workflows (`node-ci-*`): `[16.x, 18.x]` / `[20.x, 22.x]` → `[24.x]`
- Publish workflows (`npm-publish-*`): `18` → `24`

🤖 Generated with [Claude Code](https://claude.com/claude-code)