### PR TITLE
chore: bump @adobe/aio-app-builder-repos to 1.1.7

### DIFF
--- a/packages/aio-app-builder-repos/package.json
+++ b/packages/aio-app-builder-repos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/aio-app-builder-repos",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Patch version bump for `@adobe/aio-app-builder-repos` from `1.1.6` to `1.1.7`

## Test plan
- [ ] Verify package version is `1.1.7` in `packages/aio-app-builder-repos/package.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)